### PR TITLE
chore: Enable image push to gcr.io and enable caching

### DIFF
--- a/pipekit/README.md
+++ b/pipekit/README.md
@@ -9,7 +9,7 @@ You can run this using Pipekit:
 3. Install the [pre-requisites](#pre-requisites) listed below into the cluster.
 4. Create a new Pipe in Pipekit and reference `pipekit/workflow.yml` as the workflow file.
 5. Set appropriate [Run Conditions](https://docs.pipekit.io/pipekit/pipes/managing-pipes/run-conditions) to trigger the Pipe.
-6. Set up Container Repo secrets if you wish to push. You will need to call the secret `DOCKER_KEY` and it will need to contain the contents of your [JSON key file](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key).
+6. Set up Container Repo secrets if you wish to push. You will need to call the secret `DOCKER_KEY` and it will need to contain the contents of your [JSON key file](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key). A reminder: once you have created your secret in the Pipekit UI, you need to ensure that the secret environment is being used by the Run Condition, and then the PR will need to be re-triggered with a new commit to pick up the change.
 
 ## Pre-Requisites
 Your cluster will require the following to be installed:

--- a/pipekit/README.md
+++ b/pipekit/README.md
@@ -9,7 +9,7 @@ You can run this using Pipekit:
 3. Install the [pre-requisites](#pre-requisites) listed below into the cluster.
 4. Create a new Pipe in Pipekit and reference `pipekit/workflow.yml` as the workflow file.
 5. Set appropriate [Run Conditions](https://docs.pipekit.io/pipekit/pipes/managing-pipes/run-conditions) to trigger the Pipe.
-6. Set up Container Repo secrets if you wish to push.
+6. Set up Container Repo secrets if you wish to push. You will need to call the secret `DOCKER_KEY` and it will need to contain the contents of your [JSON key file](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key).
 
 ## Pre-Requisites
 Your cluster will require the following to be installed:
@@ -35,14 +35,14 @@ You can manually install the Pipekit Agent and use this cluster with Pipekit for
 
 - Checks out the repository. By default, this will check out the main branch. You can change this by setting the `branch` parameter: (`spec.arguments.parameters.git_branch.value`). When you trigger it through pipekit, the branch will be passed to the workflow automatically and will overwrite this default.
 - If `spec.arguments.parameters.push_image.value` is set to true, it will collect the container repo credentials from Pipekit and will push the image to `ghcr.io/speedscale-demos/spaceboot:latest`. If set to false, the image will be built but not pushed.
-- Builds linux/arm64 and linux/amd64 variants of the container image.
+- Builds linux/amd64 variants of the container image only. We can add more variants later if needed.
+- Uses container caching, so expect a much faster build from the second time onwards.
 
 
 ## Out of Scope
-- It does not do any image caching. This is trivial for us to add after the fact, but requires access to the container repository, so I left it alone for now.
-
 - There is no useful Java Cache. It felt unnecessary for this POC, but would be a nice thing to have to speed things up.
+- This workflow is only designed to push images to google container registry. It won't work out of the box with other registries.
 
 
 ## Issues
-I could not get the amd64 variant to build successfully on my m2 mac. If you also struggle, change the line `          --opt platform=linux/amd64,linux/arm64 ` in the workflow to remove the amd64 variant. On an EKS cluster, both built fine so it's some mac-specific issue that I wasn't too concerned about for this POC.
+I could not get the amd64 variant to build successfully on my m2 mac. If you also struggle, change the line `--opt platform=linux/amd64,linux/arm64 ` in the workflow to remove the amd64 variant. On an EKS cluster, both built fine so it's some mac-specific issue that I wasn't too concerned about for this POC.

--- a/pipekit/workflow.yml
+++ b/pipekit/workflow.yml
@@ -25,7 +25,11 @@ spec:
       - name: git_branch
         value: 'main'
       - name: push_image
-        value: 'false'
+        value: 'true'
+      - name: docker_image
+        value: "ghcr.io/speedscale-demos/spaceboot"
+      - name: docker_tag
+        value: "pipekit-latest"
   entrypoint: main
   templates:
   - name: main
@@ -58,7 +62,7 @@ spec:
           git config --global --add safe.directory /workdir/{{workflow.parameters.gh_repo}}
           git config --global user.email "sales@pipekit.io"
           git config --global user.name "Tim Collins"
-          
+
           if [ -z "$GIT_COMMIT" ]
           then
             echo "No branch specified via Pipekit, fall back to workflow param"
@@ -86,12 +90,10 @@ spec:
         - sh
         - -c
         - |
-          echo "The docker username is: ${DOCKER_USERNAME}"
-          echo "----"
-          AUTH=$(echo -n "${DOCKER_USERNAME}:${DOCKER_PASSWORD}" | base64);
+          AUTH=$(echo -n "${DOCKER_KEY}" | base64);
           echo """{
               \"auths\": {
-                  \"https://index.docker.io/v1/\": {
+                  \"gcr.io\": {
                       \"auth\": \"${AUTH}\"
                   }
               }
@@ -122,9 +124,17 @@ spec:
           --local \
           dockerfile=/tmp/workdir/{{workflow.parameters.gh_repo}} \
           --opt filename=Dockerfile \
-          --opt platform=linux/amd64,linux/arm64 \
+          --opt platform=linux/amd64 \
+          --export-cache \
+          type=registry,ref={{workflow.parameters.docker_image}}:pipekit-buildcache,mode=max,ignore-error=true \
+          --export-cache \
+          --import-cache \
+          type=registry,ref={{workflow.parameters.docker_image}}:pipekit-buildcache \
+          --import-cache \
+          type=registry,ref={{workflow.parameters.docker_image}}:{{workflow.parameters.docker_tag}} \
+          type=inline \
           --output \
-          type=image,name=ghcr.io/speedscale-demos/spaceboot:latest,push={{workflow.parameters.push_image}}
+          type=image,name={{workflow.parameters.docker_image}}:{{workflow.parameters.docker_tag}},push={{workflow.parameters.push_image}}
       env:
         - name: DOCKER_CONFIG
           value: /buildkit/.docker


### PR DESCRIPTION
- Updates the handling of the docker secret for gcr.io.
- Modifies the readme to explain that you must call your secret `DOCKER_KEY` in Pipekit.
- Adds container image caching for fun.


Note: I haven't fully tested this end-to-end, but we can keep playing on this PR until we are happy.


note: the `makefile CI` will fail because I don't have access to your git repo's secrets. It's a good thing it fails.. honest :)